### PR TITLE
Remove redundant attributes from `Field`

### DIFF
--- a/lint/internal/generators/generators.go
+++ b/lint/internal/generators/generators.go
@@ -13,9 +13,7 @@ import (
 )
 
 type Field struct {
-	ResourceName string
-	Type         string
-	ReadOnly     bool
+	Type string
 }
 
 type Generator struct {

--- a/lint/internal/parser/parser.go
+++ b/lint/internal/parser/parser.go
@@ -107,7 +107,7 @@ func (p Parser) schemaDeclToMap(schemaDecl *ast.CompositeLit) (map[string]genera
 }
 
 func parseComposite(lit *ast.CompositeLit) (*generators.Field, error) {
-	f := &generators.Field{ReadOnly: true}
+	f := &generators.Field{}
 	for i, el := range lit.Elts {
 		kv, ok := el.(*ast.KeyValueExpr)
 		if !ok {
@@ -120,15 +120,6 @@ func parseComposite(lit *ast.CompositeLit) (*generators.Field, error) {
 				return nil, fmt.Errorf("invalid `Type` field of %s", name)
 			}
 			f.Type = val.Sel.String()
-		}
-		if name == "Optional" || name == "Required" {
-			val, ok := kv.Value.(*ast.Ident)
-			if !ok {
-				return nil, fmt.Errorf("unknown `Optional`/`Required` argument type")
-			}
-			if val.Name == "true" {
-				f.ReadOnly = false
-			}
 		}
 	}
 	return f, nil


### PR DESCRIPTION
Remove `ReadOnly` and `ResourceName` attribute from `Field` type