### PR TITLE
Get rid of redundant structures and actions

### DIFF
--- a/lint/internal/core/types.go
+++ b/lint/internal/core/types.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"go/ast"
 
 	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/set"
 )
@@ -180,4 +181,21 @@ func (i *InterfaceType) String() string {
 
 func (i *InterfaceType) Matches(string) bool {
 	return true
+}
+
+func GetTypeNameOnly(exp ast.Expr) (string, error) {
+	// finding name is a shallow operation in most cases, not going deep inside
+	switch e := exp.(type) {
+	case *ast.Ident:
+		return e.Name, nil
+	case *ast.SelectorExpr:
+		xName, err := GetTypeNameOnly(e.X)
+		if err != nil {
+			return "", nil
+		}
+		return MethodName(xName, e.Sel.Name), nil
+	case *ast.StarExpr:
+		return GetTypeNameOnly(e.X)
+	}
+	return "", fmt.Errorf("getting name is not supported for expression")
 }

--- a/lint/internal/generators/generators.go
+++ b/lint/internal/generators/generators.go
@@ -25,7 +25,7 @@ type Generator struct {
 	FSet         *token.FileSet
 	Pkg          *packages.Package
 	Name         string
-	Schema       map[string]Field
+	Schema       map[string]*Field
 	OperatingFns []*ast.FuncDecl
 
 	scopeCache map[string]*core.Scope // scopes of any imported library, populated lazily
@@ -105,7 +105,7 @@ func (g Generator) getKey(key string) (*Field, error) {
 	if !ok {
 		return nil, fmt.Errorf("field missing in the schema defined in `%s`", g.Name)
 	}
-	return &fld, nil
+	return fld, nil
 }
 
 func (g Generator) ValidateSetters() error {

--- a/lint/internal/generators/schema.go
+++ b/lint/internal/generators/schema.go
@@ -1,0 +1,171 @@
+package generators
+
+import (
+	"fmt"
+	"go/ast"
+	"log"
+	"strings"
+
+	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/core"
+	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/set"
+)
+
+var usedFnNames = set.StringSetFromSlice([]string{
+	"CreateContext",
+	"Create",
+	"ReadContext",
+	"Read",
+	"UpdateContext",
+	"Update",
+})
+
+func (g *Generator) LoadSchema(lit *ast.CompositeLit) error {
+	for _, el := range lit.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		k, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			log.Printf("failed to parse field key")
+			continue
+		}
+		if usedFnNames.Contains(k.Name) {
+			ident, ok := kv.Value.(*ast.Ident)
+			if !ok {
+				log.Printf("can't parse %s field", k.Name)
+				continue
+			}
+			if ident.Obj == nil {
+				continue
+			}
+			fnDecl, ok := ident.Obj.Decl.(*ast.FuncDecl)
+			if !ok {
+				log.Printf("%s is not a function declaration", ident.Obj.Name)
+				continue
+			}
+			g.OperatingFns = append(g.OperatingFns, fnDecl)
+			continue
+		}
+		if k.Name == "Schema" {
+			cmp, ok := kv.Value.(*ast.CompositeLit)
+			if !ok {
+				return fmt.Errorf("can't find schema definition in a `Schema` field")
+			}
+			sch, err := g.schemaDeclToMap(cmp)
+			if err != nil {
+				return fmt.Errorf("error constructing resource schema: %w", err)
+			}
+			g.Schema = sch
+		}
+	}
+	return nil
+}
+
+func (g Generator) schemaDeclToMap(schemaDecl *ast.CompositeLit) (map[string]*Field, error) {
+	result := map[string]*Field{}
+	for i, el := range schemaDecl.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, fmt.Errorf("the element #%d is not a key-value element", i)
+		}
+		key := strings.Trim(kv.Key.(*ast.BasicLit).Value, `"`)
+		val, err := g.parseSchemaField(kv.Value)
+		if err != nil {
+			return nil, err
+		}
+		if val == nil {
+			log.Printf("can't process field `%s`", key)
+			continue
+		}
+		result[key] = val
+	}
+	return result, nil
+}
+
+func (g Generator) parseSchemaField(expr ast.Expr) (*Field, error) {
+	switch v := expr.(type) {
+	case *ast.CompositeLit:
+		return parseComposite(v)
+	case *ast.CallExpr:
+		return g.parseCall(v)
+	}
+	return nil, fmt.Errorf("invalid field %+v", expr)
+}
+
+func parseComposite(lit *ast.CompositeLit) (*Field, error) {
+	f := &Field{}
+	for i, el := range lit.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, fmt.Errorf("error processing element #%d of a composite", i)
+		}
+		name := kv.Key.(*ast.Ident).Name
+		if name == "Type" {
+			val, ok := kv.Value.(*ast.SelectorExpr)
+			if !ok {
+				return nil, fmt.Errorf("invalid `Type` field of %s", name)
+			}
+			f.Type = val.Sel.String()
+		}
+	}
+	return f, nil
+}
+
+func (g Generator) parseImportedFn(expr *ast.SelectorExpr) (*Field, error) {
+	dcl, err := core.ResolveImportedFunction(expr, g.Pkg)
+	if err != nil {
+		return nil, err
+	}
+	return parseFnDeclaration(dcl.Decl)
+}
+
+func parseFnDeclaration(decl *ast.FuncDecl) (*Field, error) {
+	for _, stmt := range decl.Body.List {
+		ret, ok := stmt.(*ast.ReturnStmt)
+		if !ok {
+			continue
+		}
+		if len(ret.Results) != 1 {
+			return nil, fmt.Errorf("number of returns is more than 1")
+		}
+		result := ret.Results[0]
+		var cmp *ast.CompositeLit
+		switch r := result.(type) {
+		case *ast.UnaryExpr:
+			// value defined in the return
+			cmp = r.X.(*ast.CompositeLit)
+		case *ast.Ident:
+			// if function returns some variable
+			// find the declaration
+			ass, ok := r.Obj.Decl.(*ast.AssignStmt)
+			if !ok {
+				return nil, fmt.Errorf("unknown kind of var assignment")
+			}
+			// check if we can find the value
+			if len(ass.Rhs) != 1 {
+				return nil, fmt.Errorf("too complex assignment :(")
+			}
+			// get the value and hope it's a unary expression now
+			val := ass.Rhs[0].(*ast.UnaryExpr)
+			// do the same as in the previous case
+			cmp = val.X.(*ast.CompositeLit)
+		default:
+			return nil, fmt.Errorf("unknown kind of return: %v", r)
+		}
+		return parseComposite(cmp)
+	}
+	return nil, nil
+}
+
+func (g Generator) parseCall(call *ast.CallExpr) (*Field, error) {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		// in package
+		return parseFnDeclaration(fn.Obj.Decl.(*ast.FuncDecl))
+	case *ast.SelectorExpr:
+		// imported
+		return g.parseImportedFn(fn)
+	}
+	return nil, nil
+}

--- a/lint/internal/generators/values.go
+++ b/lint/internal/generators/values.go
@@ -419,23 +419,6 @@ func builtinScope() *ast.Scope {
 
 var builtIns = builtinScope()
 
-func (g Generator) getTypeNameOnly(exp ast.Expr) (string, error) {
-	// finding name is a shallow operation in most cases, not going deep inside
-	switch e := exp.(type) {
-	case *ast.Ident:
-		return e.Name, nil
-	case *ast.SelectorExpr:
-		xName, err := g.getTypeNameOnly(e.X)
-		if err != nil {
-			return "", nil
-		}
-		return core.MethodName(xName, e.Sel.Name), nil
-	case *ast.StarExpr:
-		return g.getTypeNameOnly(e.X)
-	}
-	return "", fmt.Errorf("getting name is not supported for expression")
-}
-
 func (g Generator) getTypeSpec(spec *ast.TypeSpec, pkg *packages.Package) (core.Type, error) {
 	pScope, err := g.getCachedScope(pkg)
 	if err != nil {
@@ -498,7 +481,7 @@ func (g Generator) resolveLocalType(name string, pkg *packages.Package) (core.Ty
 		if tp, ok := scope.StructTypes[t.Name.Name]; ok {
 			return tp, nil
 		}
-		st, err := g.getTypeNameOnly(t.Type)
+		st, err := core.GetTypeNameOnly(t.Type)
 		if err != nil {
 			return g.getTypeSpec(t, pkg)
 		}
@@ -766,7 +749,7 @@ func (g Generator) getFuncReceiverName(fDecl *ast.FuncDecl) (string, error) {
 		return "", nil
 	}
 	if f := fDecl.Recv.List[0]; f != nil {
-		recvType, err := g.getTypeNameOnly(f.Type)
+		recvType, err := core.GetTypeNameOnly(f.Type)
 		if err != nil {
 			return "", err
 		}

--- a/lint/internal/parser/parser.go
+++ b/lint/internal/parser/parser.go
@@ -1,26 +1,22 @@
 package parser
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"log"
 	"path/filepath"
-	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/core"
 	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/generators"
-	"github.com/opentelekomcloud-infra/terraform-setter-lint/lint/internal/set"
 	"golang.org/x/tools/go/packages"
 )
 
 // PackageParser single package
 type PackageParser struct {
-	fSet *token.FileSet
-	pkg  *packages.Package
-	// map of file to import name
-	schemaImportNames map[token.Pos]string
-	scopeCache        map[string]*core.Scope
+	fSet       *token.FileSet
+	pkg        *packages.Package
+	scopeCache map[string]*core.Scope
 }
 
 const schemaImportPath = "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -31,219 +27,55 @@ func NewParser(pkg *packages.Package, set *token.FileSet, scopeCache map[string]
 		fSet:       set,
 		scopeCache: scopeCache,
 	}
-	p.schemaImportNames = p.findImportNames(schemaImportPath)
 	return p
 }
-
-var usedFnNames = set.StringSetFromSlice([]string{
-	"CreateContext",
-	"Create",
-	"ReadContext",
-	"Read",
-	"UpdateContext",
-	"Update",
-})
 
 func (p PackageParser) ParseGenerator(lit *ast.CompositeLit, genName string) (*generators.Generator, error) {
 	gen, err := generators.NewGenerator(genName, p.fSet, p.pkg, p.scopeCache)
 	if err != nil {
 		return nil, err
 	}
-	for _, el := range lit.Elts {
-		kv, ok := el.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		k, ok := kv.Key.(*ast.Ident)
-		if !ok {
-			log.Printf("failed to parse field key")
-			continue
-		}
-		if usedFnNames.Contains(k.Name) {
-			ident, ok := kv.Value.(*ast.Ident)
-			if !ok {
-				log.Printf("can't parse %s field", k.Name)
-				continue
-			}
-			if ident.Obj == nil {
-				continue
-			}
-			fnDecl, ok := ident.Obj.Decl.(*ast.FuncDecl)
-			if !ok {
-				log.Printf("%s is not a function declaration", ident.Obj.Name)
-				continue
-			}
-			gen.OperatingFns = append(gen.OperatingFns, fnDecl)
-			continue
-		}
-		if k.Name == "Schema" {
-			cmp, ok := kv.Value.(*ast.CompositeLit)
-			if !ok {
-				return nil, fmt.Errorf("can't find schema definition in a `Schema` field")
-			}
-			sch, err := p.schemaDeclToMap(cmp)
-			if err != nil {
-				return nil, fmt.Errorf("error constructing resource schema: %w", err)
-			}
-			gen.Schema = sch
-		}
+	err = gen.LoadSchema(lit)
+	if err != nil {
+		return nil, err
 	}
 	return gen, nil
 }
 
-func (p PackageParser) schemaDeclToMap(schemaDecl *ast.CompositeLit) (map[string]generators.Field, error) {
-	result := map[string]generators.Field{}
-	for i, el := range schemaDecl.Elts {
-		kv, ok := el.(*ast.KeyValueExpr)
-		if !ok {
-			return nil, fmt.Errorf("the element #%d is not a key-value element", i)
-		}
-		key := strings.Trim(kv.Key.(*ast.BasicLit).Value, `"`)
-		val, err := p.parseSchemaField(kv.Value)
-		if err != nil {
-			return nil, err
-		}
-		if val == nil {
-			log.Printf("can't process field `%s`", key)
+func getSchemaImportName(file *ast.File) string {
+	for _, imp := range file.Imports {
+		val, _ := core.UnwrapString(imp.Path)
+		if val != schemaImportPath {
 			continue
 		}
-		result[key] = *val
-	}
-	return result, nil
-}
-
-func parseComposite(lit *ast.CompositeLit) (*generators.Field, error) {
-	f := &generators.Field{}
-	for i, el := range lit.Elts {
-		kv, ok := el.(*ast.KeyValueExpr)
-		if !ok {
-			return nil, fmt.Errorf("error processing element #%d of a composite", i)
-		}
-		name := kv.Key.(*ast.Ident).Name
-		if name == "Type" {
-			val, ok := kv.Value.(*ast.SelectorExpr)
-			if !ok {
-				return nil, fmt.Errorf("invalid `Type` field of %s", name)
-			}
-			f.Type = val.Sel.String()
+		if imp.Name != nil {
+			return imp.Name.Name
+		} else {
+			return filepath.Base(val) // set alias to module name
 		}
 	}
-	return f, nil
+	return ""
 }
 
-func (p PackageParser) parseImportedFn(expr *ast.SelectorExpr) (*generators.Field, error) {
-	dcl, err := core.ResolveImportedFunction(expr, p.pkg)
-	if err != nil {
-		return nil, err
-	}
-	return parseFnDeclaration(dcl.Decl, dcl.Package)
-}
-
-func parseFnDeclaration(decl *ast.FuncDecl, pkg *packages.Package) (*generators.Field, error) {
-	for _, stmt := range decl.Body.List {
-		ret, ok := stmt.(*ast.ReturnStmt)
-		if !ok {
-			continue
-		}
-		if len(ret.Results) != 1 {
-			return nil, fmt.Errorf("number of returns is more than 1")
-		}
-		result := ret.Results[0]
-		var cmp *ast.CompositeLit
-		switch r := result.(type) {
-		case *ast.UnaryExpr:
-			// value defined in the return
-			cmp = r.X.(*ast.CompositeLit)
-		case *ast.Ident:
-			// if function returns some variable
-			// find the declaration
-			ass, ok := r.Obj.Decl.(*ast.AssignStmt)
-			if !ok {
-				return nil, fmt.Errorf("unknown kind of var assignment")
-			}
-			// check if we can find the value
-			if len(ass.Rhs) != 1 {
-				return nil, fmt.Errorf("too complex assignment :(")
-			}
-			// get the value and hope it's a unary expression now
-			val := ass.Rhs[0].(*ast.UnaryExpr)
-			// do the same as in the previous case
-			cmp = val.X.(*ast.CompositeLit)
-		default:
-			return nil, fmt.Errorf("unknown kind of return: %v", r)
-		}
-		return parseComposite(cmp)
-	}
-	return nil, nil
-}
-
-func (p PackageParser) parseCall(call *ast.CallExpr) (*generators.Field, error) {
-	switch fn := call.Fun.(type) {
-	case *ast.Ident:
-		// in package
-		return parseFnDeclaration(fn.Obj.Decl.(*ast.FuncDecl), p.pkg)
-	case *ast.SelectorExpr:
-		// imported
-		return p.parseImportedFn(fn)
-	}
-	return nil, nil
-}
-
-func (p PackageParser) parseSchemaField(expr ast.Expr) (*generators.Field, error) {
-	switch v := expr.(type) {
-	case *ast.CompositeLit:
-		return parseComposite(v)
-	case *ast.CallExpr:
-		return p.parseCall(v)
-	}
-	return nil, fmt.Errorf("invalid field %+v", expr)
-}
-
-func (p PackageParser) FindFnObject(name string) *ast.Object {
-	for _, fl := range p.pkg.Syntax {
-		for _, obj := range fl.Scope.Objects {
-			if obj.Name == name {
-				return obj
-			}
-		}
-	}
-	return nil
-}
-
-func (p PackageParser) findImportNames(iPath string) map[token.Pos]string {
-	imports := make(map[token.Pos]string)
-	for _, fl := range p.pkg.Syntax {
-		pos := fl.Pos()
-		for _, imp := range fl.Imports {
-			val, _ := core.UnwrapString(imp.Path)
-			if val != iPath {
-				continue
-			}
-			if imp.Name != nil {
-				imports[pos] = imp.Name.Name
-			} else {
-				imports[pos] = filepath.Base(val) // set alias to module name
-			}
-		}
-	}
-	return imports
-}
-
-func (p PackageParser) GeneratorNames() (names []string) {
+func (p PackageParser) GeneratorFns() map[string]*ast.Object {
+	gens := map[string]*ast.Object{}
 	files := p.pkg.Syntax
 	for _, f := range files {
 		for name, obj := range f.Scope.Objects {
-			if !p.isGeneratorFn(obj, f.Pos()) {
+			schemaImportName := getSchemaImportName(f)
+			if schemaImportName == "" {
+				continue // no `schema` import found, skip the file
+			}
+			if !isGeneratorFn(obj, schemaImportName) {
 				continue
 			}
-			names = append(names, name)
+			gens[name] = obj
 		}
 	}
-
-	return
+	return gens
 }
 
-func (p PackageParser) isGeneratorFn(obj *ast.Object, filePos token.Pos) bool {
+func isGeneratorFn(obj *ast.Object, schemaImportName string) bool {
 	fn, ok := obj.Decl.(*ast.FuncDecl)
 	if !ok {
 		return false
@@ -260,5 +92,29 @@ func (p PackageParser) isGeneratorFn(obj *ast.Object, filePos token.Pos) bool {
 	if !ok {
 		return false
 	}
-	return sel.X.(*ast.Ident).Name == p.schemaImportNames[filePos] && sel.Sel.Name == "Resource"
+	return sel.X.(*ast.Ident).Name == schemaImportName && sel.Sel.Name == "Resource"
+}
+
+func (p PackageParser) Validate() error {
+	generatorFns := p.GeneratorFns()
+	if l := len(generatorFns); l != 0 {
+		log.Printf("found %d generator(s) in package %s", l, p.pkg.ID)
+	}
+	mErr := &multierror.Error{}
+	for name, fnObj := range generatorFns {
+		ast.Inspect(fnObj.Decl.(*ast.FuncDecl), func(node ast.Node) bool {
+			lit, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			gen, err := p.ParseGenerator(lit, name)
+			if err != nil {
+				log.Println(err)
+				return false
+			}
+			mErr = multierror.Append(mErr, gen.ValidateSetters())
+			return false
+		})
+	}
+	return mErr.ErrorOrNil()
 }


### PR DESCRIPTION
Move schema parsing methods to `Generator`

Get rid of `validator` structure

Decrease number of walks through generator files

Remove receivers from certain functions