### PR TITLE
Improve handling of unresolved vars in setter

### DIFF
--- a/tests/fixtures/bad_types/example.go.tmpl
+++ b/tests/fixtures/bad_types/example.go.tmpl
@@ -132,6 +132,7 @@ func resourceIdentityRoleAssignmentV3Read(_ context.Context, d *schema.ResourceD
 		d.Set("user_id", userID),
 		d.Set("role_id", roleAssignment.ID),
 		d.Set("localWithReturn", "test"),
+		d.Set("read_only_field", asd),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)

--- a/tests/lint_test.go
+++ b/tests/lint_test.go
@@ -110,13 +110,14 @@ func TestValidateNegativeBadTypes(t *testing.T) {
 	require.Error(t, err)
 	t.Log(err)
 	me := err.(*multierror.Error)
-	assert.Len(t, me.Errors, 2)
+	assert.Len(t, me.Errors, 3)
 }
 
 func TestValidateAcceptance(t *testing.T) {
 	err := lint.Validate(fixturePath("complicated"))
 	require.NoError(t, err)
 }
+
 func TestValidateAcceptance2(t *testing.T) {
 	providerPath := "../../terraform-provider-opentelekomcloud"
 	if _, err := os.Open(providerPath); os.IsNotExist(err) {


### PR DESCRIPTION
Not resolved variables are now reported with `unknown type` error rather than error during type checking