### PR TITLE
Make schema analyzing more standard

### DIFF
--- a/lint/internal/core/common.go
+++ b/lint/internal/core/common.go
@@ -3,7 +3,6 @@ package core
 import (
 	"fmt"
 	"go/ast"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -27,48 +26,4 @@ func MethodName(receiver, fnc string) string {
 		return fnc
 	}
 	return fmt.Sprintf("%s.%s", receiver, fnc)
-}
-
-func ResolveImportedDeclaration(expr *ast.SelectorExpr, pkg *packages.Package) (*ast.Object, *packages.Package, error) {
-	imps := pkg.Imports
-	pkgName := expr.X.(*ast.Ident).Name
-	fnName := expr.Sel.Name
-
-	for k, imp := range imps {
-		name := imp.Name
-		if name == "" {
-			name = filepath.Base(k) // hope this always works
-		}
-		if name != pkgName {
-			continue
-		}
-		for _, fl := range imp.Syntax {
-			dcl := fl.Scope.Lookup(fnName)
-			if dcl == nil {
-				continue
-			}
-			return dcl, imp, nil
-		}
-	}
-	return nil, nil, fmt.Errorf("failed to resolve imported declaration %s.%s", pkgName, fnName) // pragma:nocover
-}
-
-type FunctionReference struct {
-	Package *packages.Package
-	Decl    *ast.FuncDecl
-}
-
-func ResolveImportedFunction(expr *ast.SelectorExpr, pkg *packages.Package) (*FunctionReference, error) {
-	fnDcl, srcPkg, err := ResolveImportedDeclaration(expr, pkg)
-	if err != nil {
-		return nil, err
-	}
-	dcl, ok := fnDcl.Decl.(*ast.FuncDecl)
-	if !ok {
-		return nil, fmt.Errorf("invalid function declaration for %s", fnDcl.Name)
-	}
-	return &FunctionReference{
-		Package: srcPkg,
-		Decl:    dcl,
-	}, nil
 }


### PR DESCRIPTION
Move to more standard approach for imported function
search during schema parsing

Get rid of functions used only for schema fields
configured with a function call (e.g. `"tags": common.TagsSchema()`)